### PR TITLE
Set an initial value for width&height

### DIFF
--- a/ch_04/lib/pong.dart
+++ b/ch_04/lib/pong.dart
@@ -13,8 +13,8 @@ class Pong extends StatefulWidget {
 
 class _PongState extends State<Pong> with SingleTickerProviderStateMixin {
 
-  double width;
-  double height;
+  double width = 0;
+  double height = 0;
   double posX;
   double posY;
   double batWidth;


### PR DESCRIPTION
If we don't set an initial value for width&height AnimationController throw Exception. Because, in the initState() we use checkBorders() and we check [width-50 and height-50].
If we don't use initial value chechBorders() try null-50.