### PR TITLE
missing toString() call at line 81

### DIFF
--- a/ch_05/lib/movie_list.dart
+++ b/ch_05/lib/movie_list.dart
@@ -78,7 +78,7 @@ class _MovieListState extends State<MovieList> {
                     ),
                     title: Text(movies[position].title),
                     subtitle: Text('Released: ' +
-                        movies[position].releaseDate +
+                        movies[position].releaseDate.toString() +
                         ' - Vote: ' +
                         movies[position].voteAverage.toString()),
                   ));


### PR DESCRIPTION
Without the toString method we get the following error and stacktrace:

When the exception was thrown, this was the stack:
#0      _StringBase.+ (dart:core-patch/string_patch.dart:267:57)
#1      _MovieListState.build.<anonymous closure> (package:movie_app/movie_list.dart:29:45)